### PR TITLE
adding option to disable iterator parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Chris Martin, John Papa, Shayne Boyer!
 ```
 
 See the [each block helper](http://handlebarsjs.com/builtin_helpers.html#iteration) docs page for more information.
-
+You can disable this behaviour by passing the option `--no_arrays` to the `envhandlebars` command if you have env variables that conflict with this convention and you don't want to use iterators.
 
 ## Docker Usage
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = function envhandlebars(opts, cb) {
         var arrRegexp = /^(.*?)_(\d+)_?(.*)$/g;
         var match = arrRegexp.exec(keypart);
 
-        if (match) {
+        if (match && opts.argv.indexOf('--no_arrays') === -1) {
             if (!vars[match[1]]) {
                 vars[match[1]] = [];
             }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -68,7 +68,7 @@ describe('envhandlebars', function() {
     });
 
     describe('iterator expressions', function () {
-        it('should not render array of strings', function (done) {
+        it('should not render array of strings if --no_arrays is used', function (done) {
             var stdin = new stream.ReadableStream(
                 "{{#each PEOPLE}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}!"
             );

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -68,6 +68,24 @@ describe('envhandlebars', function() {
     });
 
     describe('iterator expressions', function () {
+        it('should not render array of strings', function (done) {
+            var stdin = new stream.ReadableStream(
+                "{{#each PEOPLE}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}!"
+            );
+            fixture({
+                env: {
+                    PEOPLE_0: 'Chris',
+                    PEOPLE_1: 'John',
+                    PEOPLE_2: 'Shayne'
+                },
+                stdin: stdin, stdout: stdout, stderr: stderr,
+                argv: argv.concat(['--no_arrays'])
+            }, function (err) {
+                assert.ifError(err);
+                assert.equal(stdout.toString(), '!');
+                done();
+            });
+        });
         it('should render array of strings', function (done) {
             var stdin = new stream.ReadableStream(
                 "{{#each PEOPLE}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}!"


### PR DESCRIPTION
This should fix #7 by adding a `--no_arrays` option to disable the parsing of the env vars special naming convention for iterators.

I'm not very experienced with nodejs and this is probably not the best implementation possible but it solves our problem...

I'm open to suggestions for better implementations.