### PR TITLE
adding --array_var_prefix option to filter iterator vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Chris Martin, John Papa, Shayne Boyer!
 ```
 
 See the [each block helper](http://handlebarsjs.com/builtin_helpers.html#iteration) docs page for more information.
+
 You can disable this behaviour by passing the option `--no_arrays` to the `envhandlebars` command if you have env variables that conflict with this convention and you don't want to use iterators.
+Or you can use `--array_var_prefix=FOO_` to parse only variables that start with `FOO_`
 
 ## Docker Usage
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function envhandlebars(opts, cb) {
     opts.stdout = opts.stdout || process.stdout;
     opts.stderr = opts.stderr || process.stderr;
     opts.argv = opts.argv || process.argv;
+    opts.argv = require('minimist')(opts.argv.slice(2));
 
     cb = cb || function(err) {
         if (err) {
@@ -55,10 +56,15 @@ module.exports = function envhandlebars(opts, cb) {
     }
 
     function parseVar(vars, keypart, key) {
-        var arrRegexp = /^(.*?)_(\d+)_?(.*)$/g;
+        var arrPatternPrefix = '^(.*?)_';
+        if (opts.argv.array_var_prefix) {
+            arrPatternPrefix = '^(' + opts.argv.array_var_prefix + '.*?)_'
+        }
+        var arrPattern = '(\\d+)_?(.*)$';
+        var arrRegexp = new RegExp(arrPatternPrefix + arrPattern, 'g')
         var match = arrRegexp.exec(keypart);
 
-        if (match && opts.argv.indexOf('--no_arrays') === -1) {
+        if (match && !opts.argv.no_arrays) {
             if (!vars[match[1]]) {
                 vars[match[1]] = [];
             }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "template"
   ],
   "dependencies": {
+    "minimist": "^1.2.0",
     "concat-stream": "^1.6.0",
     "handlebars": "^4.0.6"
   },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -86,6 +86,27 @@ describe('envhandlebars', function() {
                 done();
             });
         });
+        it('should only render one array of strings if --array_var_prefix is used', function (done) {
+            var stdin = new stream.ReadableStream(
+                "{{#each PEOPLE}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}!{{#each ARR_PEOPLE}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}!"
+            );
+            fixture({
+                env: {
+                    PEOPLE_0: 'Chris',
+                    PEOPLE_1: 'John',
+                    PEOPLE_2: 'Shayne',
+                    ARR_PEOPLE_0: 'Patrick',
+                    ARR_PEOPLE_1: 'Sean',
+                    ARR_PEOPLE_2: 'Liam'
+                },
+                stdin: stdin, stdout: stdout, stderr: stderr,
+                argv: argv.concat(['--array_var_prefix=ARR_'])
+            }, function (err) {
+                assert.ifError(err);
+                assert.equal(stdout.toString(), '!Patrick, Sean, Liam!');
+                done();
+            });
+        });
         it('should render array of strings', function (done) {
             var stdin = new stream.ReadableStream(
                 "{{#each PEOPLE}}{{this}}{{#unless @last}}, {{/unless}}{{/each}}!"


### PR DESCRIPTION
This implements the solution proposed by @cgmartin in #7 
These changes introduce a new dependency, `envhandlebars` now depends on `minimist` but I think it's better to use a lib to parse the arguments instead of re-inventing the wheel.